### PR TITLE
__isset magic method doesn't check for main table

### DIFF
--- a/src/Polyglot/Polyglot.php
+++ b/src/Polyglot/Polyglot.php
@@ -137,7 +137,9 @@ abstract class Polyglot extends Model
 	public function __isset($key)
 	{
 		if ($this->polyglot) {
-			if(in_array($key, $this->getPolyglotAttributes())) return true;
+			if(in_array($key, $this->getPolyglotAttributes())) {
+				return true;
+			}
 		}
 
 		return parent::__isset($key);

--- a/src/Polyglot/Polyglot.php
+++ b/src/Polyglot/Polyglot.php
@@ -137,7 +137,7 @@ abstract class Polyglot extends Model
 	public function __isset($key)
 	{
 		if ($this->polyglot) {
-			return in_array($key, $this->getPolyglotAttributes());
+			if(in_array($key, $this->getPolyglotAttributes())) return true;
 		}
 
 		return parent::__isset($key);

--- a/tests/Dummies/Article.php
+++ b/tests/Dummies/Article.php
@@ -16,4 +16,9 @@ class Article extends Polyglot
 	{
 		return new $related;
 	}
+
+	public function getAgbAcceptedAttribute()
+	{
+		return 1;
+	}
 }

--- a/tests/PolyglotTest.php
+++ b/tests/PolyglotTest.php
@@ -15,5 +15,6 @@ class PolyglotTest extends PolyglotTests
 		$article = new Article;
 
 		$this->assertTrue(isset($article->name));
+		$this->assertTrue(isset($article->agb_accepted));
 	}
 }


### PR DESCRIPTION
I ran in an issue where form fields created with the form builder didn't pre-populate correctly. 

After some debugging I found out that polyglot does only check the *_lang table if there are any translated attributes. Because e.g. checkbox values don't need translations, they shouldn't bee stored in the *_lang table, but instead stay in the 'normal' table. 

My pull request fixes this issue. Polyglot now checks if there's a translated version of this attribute first and if not, just delegates to the parent __isset method. Like that we achieve the desired behavior.
