### PR TITLE
Fix URL::locale() when locale is not into url

### DIFF
--- a/src/Polyglot/Polyglot.php
+++ b/src/Polyglot/Polyglot.php
@@ -103,54 +103,14 @@ abstract class Polyglot extends Model
 		return $this->hasMany($this->getLangClass());
 	}
 
-	public function fr()
-	{
-		return $this->hasOne($this->getLangClass())->whereLang('fr');
-	}
-
-    public function en()
-    {
-        return $this->hasOne($this->getLangClass())->whereLang('en');
-    }
-
-    public function es()
-    {
-        return $this->hasOne($this->getLangClass())->whereLang('es');
-    }
-
-    public function pt()
-    {
-        return $this->hasOne($this->getLangClass())->whereLang('pt');
-    }
-
-    public function de()
-    {
-        return $this->hasOne($this->getLangClass())->whereLang('de');
-    }
-
-    public function it()
-    {
-        return $this->hasOne($this->getLangClass())->whereLang('it');
-    }
-
-    public function pl()
-    {
-        return $this->hasOne($this->getLangClass())->whereLang('pl');
-    }
-
-    public function tr()
-    {
-        return $this->hasOne($this->getLangClass())->whereLang('tr');
-    }
-
-    public function sv()
-    {
-        return $this->hasOne($this->getLangClass())->whereLang('sv');
-    }
-
-    public function zn()
-    {
-        return $this->hasOne($this->getLangClass())->whereLang('zn');
+    public function __call($langOrMethod, $parameters)
+    {        
+        if (in_array($langOrMethod, Config::get('polyglot::locales')))
+        {
+            return $this->hasOne($this->getLangClass())->whereLang($langOrMethod);
+        }
+        
+        return parent::__call($langOrMethod, $parameters);
     }
 
 	////////////////////////////////////////////////////////////////////

--- a/src/Polyglot/Polyglot.php
+++ b/src/Polyglot/Polyglot.php
@@ -155,7 +155,16 @@ abstract class Polyglot extends Model
 	{
 		// If the attribute is set to be automatically localized
 		if ($this->polyglot) {
-			if (in_array($key, $this->polyglot)) {
+			$camelKey = camel_case($key);
+
+            if ( in_array( $camelKey, Config::get('polyglot::locales') ) ) {
+                if( ! array_key_exists($key, $this->relations) )
+                {
+                    return $this->getRelationshipFromMethod($key, $camelKey);
+                }
+            }
+            
+            if (in_array($key, $this->polyglot)) {
 				$lang = LangFacade::getLocale();
 
 				return $this->$lang ? $this->$lang->$key : null;

--- a/src/Polyglot/Polyglot.php
+++ b/src/Polyglot/Polyglot.php
@@ -105,11 +105,10 @@ abstract class Polyglot extends Model
 
     public function __call($langOrMethod, $parameters)
     {        
-        if (in_array($langOrMethod, Config::get('polyglot::locales')))
-        {
+        if (in_array($langOrMethod, Config::get('polyglot::locales'))) {
             return $this->hasOne($this->getLangClass())->whereLang($langOrMethod);
         }
-        
+
         return parent::__call($langOrMethod, $parameters);
     }
 

--- a/src/Polyglot/UrlGenerator.php
+++ b/src/Polyglot/UrlGenerator.php
@@ -2,6 +2,7 @@
 namespace Polyglot;
 
 use Illuminate\Routing\UrlGenerator as IlluminateUrlGenerator;
+use Illuminate\Support\Facades\Lang as LangFacade;
 
 /**
  * An UrlGenerator with localization capacities
@@ -15,7 +16,7 @@ class UrlGenerator extends IlluminateUrlGenerator
 	 */
 	public function locale()
 	{
-		return $this->request->segment(1);
+		return LangFacade::getLocale();
 	}
 
 	/**


### PR DESCRIPTION
Fix issue #8 (URL::locale function doesn't return the default locale when the url doesn't contains it)

Signed-off-by: Mathieu Doyon mathieu.doyon@studiofrenetic.com
