### PR TITLE
fix the failing tests

### DIFF
--- a/src/Polyglot/PolyglotServiceProvider.php
+++ b/src/Polyglot/PolyglotServiceProvider.php
@@ -86,7 +86,9 @@ class PolyglotServiceProvider extends ServiceProvider
 		$app->singleton('url', function ($app) {
 			$routes = $app['router']->getRoutes();
 
-			return new UrlGenerator($routes, $app['request']);
+			return new UrlGenerator($routes, $app->rebinding('request', function($app, $request) {
+				$app['url']->setRequest($request);
+			}));
 		});
 
 		return $app;

--- a/tests/Dummies/Article.php
+++ b/tests/Dummies/Article.php
@@ -12,7 +12,7 @@ class Article extends Polyglot
 	 *
 	 * @return object
 	 */
-	public function hasOne($related, $foreignKey = NULL)
+	public function hasOne($related, $foreignKey = null, $localKey = null)
 	{
 		return new $related;
 	}

--- a/tests/Dummies/ArticleLang.php
+++ b/tests/Dummies/ArticleLang.php
@@ -5,7 +5,7 @@ class ArticleLang extends Model
 {
 	public function whereLang($lang)
 	{
-		$relation = Mockery::mock('relation');
+		$relation = Mockery::mock('Illuminate\Database\Eloquent\Relations\Relation');
 		$relation->shouldReceive('getResults')->andReturnUsing(function() use ($relation) {
 			return $relation;
 		});

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -44,7 +44,7 @@ class RouterTest extends PolyglotTests
 			$route = $r;
 		}
 
-		$this->assertEquals('/en/foobar', $route->getPath());
+		$this->assertEquals('en/foobar', $route->getPath());
 	}
 
 	public function testCanCreateGroupsWithoutArrays()
@@ -60,6 +60,6 @@ class RouterTest extends PolyglotTests
 			$route = $r;
 		}
 
-		$this->assertEquals('/en/foobar', $route->getPath());
+		$this->assertEquals('en/foobar', $route->getPath());
 	}
 }

--- a/tests/_start.php
+++ b/tests/_start.php
@@ -22,8 +22,10 @@ abstract class PolyglotTests extends PHPUnit_Framework_TestCase
 	 */
 	public function setUp()
 	{
+		date_default_timezone_set('Europe/London');
 		$this->app = new Container;
 		$this->app['config']  = $this->mockConfig();
+		$this->app['events']  = Mockery::mock('Illuminate\Events\Dispatcher');
 		$this->app->instance('request', $this->mockRequest());
 		$this->app['translation.loader'] = Mockery::mock('Illuminate\Translation\FileLoader');
 


### PR DESCRIPTION
Fix the different failing tests
- mock the events Dispatcher to avoid the error: `ReflectionException: Class events does not exist`
- fix the TMZ to avoid the error: `mktime(): It is not safe to rely on the system's timezone settings.`
- fix the Article::hasOne signature to avoid the warning: `Declaration of Article::hasOne() should be compatible...`
- specify the relation mock class in ArticleLang to avoid the error: `LogicException: Relationship method must return an object of type Illuminate\Database\Eloquent\Relations\Relation`
- remove trailing slash in expected route paths
