### PR TITLE
Revert to the fallback locale for translations

### DIFF
--- a/src/Polyglot/Polyglot.php
+++ b/src/Polyglot/Polyglot.php
@@ -175,6 +175,10 @@ abstract class Polyglot extends Model
 		if (in_array($key, $this->getLocales())) {
 			$relation = $this->hasOne($this->getLangClass())->whereLang($key);
 
+			if ($relation->getResults() === null) {
+				$relation = $this->hasOne($this->getLangClass())->whereLang(Config::get('polyglot::fallback'));
+			}
+
 			return $this->relations[$key] = $relation->getResults();
 		}
 


### PR DESCRIPTION
If a language translation is requested and doesn't exist then attempt to load the fallback translation. If the fallback translation doesn't exist either then the same result will be returned (i.e. a NULL result).
