### PR TITLE
Updated test case for fallback locale gets

### DIFF
--- a/tests/Dummies/ArticleLang.php
+++ b/tests/Dummies/ArticleLang.php
@@ -13,7 +13,7 @@ class ArticleLang extends Model
 			return $relation;
 		});
 
-		$relation->name = $lang == 'fr' ? 'Nom' : 'Name';
+		$relation->name = $lang == 'en' ? 'Name' : 'Nom';
 
 		return $relation;
 	}

--- a/tests/PolyglotTest.php
+++ b/tests/PolyglotTest.php
@@ -12,6 +12,7 @@ class PolyglotTest extends PolyglotTestCase
 
 		$this->assertEquals('Name', $article->en->name);
 		$this->assertEquals('Nom', $article->fr->name);
+		$this->assertEquals('Nom', $article->de->name);
 		$this->assertEquals('Nom', $article->name);
 	}
 

--- a/tests/TestCases/ContainerTestCase.php
+++ b/tests/TestCases/ContainerTestCase.php
@@ -132,7 +132,7 @@ abstract class ContainerTestCase extends PHPUnit_Framework_TestCase
 		$config = Mockery::mock('Illuminate\Config\Repository');
 		$config->shouldReceive('get')->with('app.locale')->andReturn('fr');
 		$config->shouldReceive('get')->with('polyglot::default')->andReturn('fr');
-		$config->shouldReceive('get')->with('polyglot::locales')->andReturn(array('fr', 'en'));
+		$config->shouldReceive('get')->with('polyglot::locales')->andReturn(array('fr', 'en', 'de'));
 		$config->shouldReceive('get')->with('polyglot::model_pattern')->andReturn('Polyglot\Dummies\{model}Lang');
 		$config->shouldReceive('package');
 

--- a/tests/TestCases/DatabaseTestCase.php
+++ b/tests/TestCases/DatabaseTestCase.php
@@ -117,7 +117,7 @@ class DatabaseTestCase extends PHPUnit_Framework_TestCase
 		$config = \Mockery::mock('Illuminate\Config\Repository');
 		$config->shouldReceive('get')->with('app.locale')->andReturn('fr');
 		$config->shouldReceive('get')->with('polyglot::default')->andReturn('fr');
-		$config->shouldReceive('get')->with('polyglot::locales')->andReturn(array('fr', 'en'));
+		$config->shouldReceive('get')->with('polyglot::locales')->andReturn(array('fr', 'en', 'de'));
 		$config->shouldReceive('get')->with('polyglot::model_pattern')->andReturn('Polyglot\Dummies\{model}Lang');
 		$config->shouldReceive('package');
 


### PR DESCRIPTION
Sorry. I forgot to update the test cases.

This checks to see if the 'de' locale falls back to the 'fr' default locale.
