### PR TITLE
Check to make sure that the fallback lang wasn't returned when saving new ones

### DIFF
--- a/src/Polyglot/Polyglot.php
+++ b/src/Polyglot/Polyglot.php
@@ -56,8 +56,8 @@ abstract class Polyglot extends Model
 				$model->save();
 			}
 
-			// If no Lang model, create one
-			if (!$langModel) {
+			// If no Lang model or the fallback was returned, create a new one
+			if (!$langModel || ($langModel->lang !== $lang)) {
 				$langModel = $model->getLangClass();
 				$langModel = new $langModel($translated);
 				$model->translations()->save($langModel);


### PR DESCRIPTION
Because the fallback locale is now returned when a requested one isn't found
when an attempt to save a new locale is made, it would overwrite the fallback.
This means that we need to check that the returned langModel is actually the
same language of the one we are trying to save.

I had a look at creating a test case for this, but I was unsure how to get it to work.
