### PR TITLE
Fix bug where the default locale wasn't working

### DIFF
--- a/src/Services/Lang.php
+++ b/src/Services/Lang.php
@@ -267,6 +267,9 @@ class Lang extends Translator
 		$locales = array(
 			'en' => 'en_US',
 			'zh' => 'zh_CN',
+			'es' => 'es_ES',
+			'fr' => 'fr_FR',
+			'de' => 'de_DE'
 		);
 
 		// Get correct locale

--- a/src/Services/Router.php
+++ b/src/Services/Router.php
@@ -38,7 +38,7 @@ class Router extends IlluminateRouter
 	public function getRoutesPrefix($group = array())
 	{
 		// Get locale
-		$locale = $this->container['polyglot.url']->locale();
+		$locale = $this->container['polyglot.url']->locale() ?: $this->container['config']->get('polyglot::default');
 
 		// Cancel if invalid locale in URL
 		if (!$this->container['translator']->valid($locale)) {
@@ -49,7 +49,7 @@ class Router extends IlluminateRouter
 		$this->container['translator']->setLocale($locale);
 
 		// Return group untouched if default
-		if ($locale == $this->container['config']->get('polyglot::default')) {
+		if ($locale == $this->container['config']->get('polyglot::default') && !$this->container['url']->locale()) {
 			return $group;
 		}
 


### PR DESCRIPTION
I have a really simple setup, with two locales: `es`, `en`, being `es` the default one. I can access urls such as `example.com/blog` (default locale) or `example.com/en/blog` (English), but when I try `example.com/es/blog` I get a 404.

I've been able to solve that by adding some extra checks. I was just hoping for you to review it and tell me what you think! Maybe I've misunderstood something about the configuration!
